### PR TITLE
Stop implying that LazyLib is already imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See that in `src`, we have `author.modname` as the package (which matches the fo
 
 ## Adding more dependencies/libraries
 
-LazyLib not enough?
+Need to depend on another mod or library (e.g. [GraphicsLib], [LazyLib], [LunaLib], [MagicLib], [Nexelerin], etc)?
 
 1. `File -> Project Structure -> Modules -> "starsector-intellij-template" -> Dependencies tab -> + icon -> JARS or
    Directories`. Select the .jar(s) you want to add.
@@ -121,3 +121,9 @@ LazyLib not enough?
 Author: Wisp
 
 Lowtech Tempest: Selkie
+
+[GraphicsLib]: https://bitbucket.org/DarkRevenant/graphicslib/
+[MagicLib]: https://github.com/MagicLibStarsector/MagicLib/
+[LazyLib]: https://github.com/LazyWizard/lazylib/
+[LunaLib]: https://github.com/Lukas22041/LunaLib/
+[Nexelerin]: https://github.com/Histidine91/Nexerelin/

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Author: Wisp
 
 Lowtech Tempest: Selkie
 
-[GraphicsLib]: https://bitbucket.org/DarkRevenant/graphicslib/
+[GraphicsLib]: https://fractalsoftworks.com/forum/index.php?topic=10982.0
 [MagicLib]: https://github.com/MagicLibStarsector/MagicLib/
 [LazyLib]: https://github.com/LazyWizard/lazylib/
 [LunaLib]: https://github.com/Lukas22041/LunaLib/


### PR DESCRIPTION
As far as I can tell, LazyLib is not imported in this template (I got an import error).

I've also added some links to commonly used dependencies to hint to point mod developers towards things they might want to use.