### PR TITLE
Use Starsector's bundled JRE

### DIFF
--- a/.run/Run Starsector.run.xml
+++ b/.run/Run Starsector.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Starsector" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="1.7" />
+    <option name="ALTERNATIVE_JRE_PATH" value="C:/Program Files (x86)/Fractal Softworks/Starsector/jre" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.fs.starfarer.StarfarerLauncher" />
     <module name="starsector-intellij-template" />


### PR DESCRIPTION
I don't know if this is a good idea, but I thought I'd suggest it so I could find out why it's this way around :)

If we specify the JRE bundled with starsector then the debug environment in the IDE will more closely match the run environment when not using the IDE (at least on the developer's machine). I don't know if Starsector ships with a modified copy of the JRE, but I know that lots of users use JRE 8 instead, which might be relevant.